### PR TITLE
Adds a name to Deployments and fix duplicates of DeploymentInstances

### DIFF
--- a/cleanup/instances.go
+++ b/cleanup/instances.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Dolittle. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package cleanup
+
+import (
+	"context"
+	"dolittle.io/fleet-observer/storage"
+	"fmt"
+	"github.com/rs/zerolog"
+	"k8s.io/apimachinery/pkg/labels"
+	v1 "k8s.io/client-go/listers/core/v1"
+	"time"
+)
+
+type Instances struct {
+	deployments  storage.Deployments
+	environments storage.Environments
+	applications storage.Applications
+	pods         v1.PodLister
+	logger       zerolog.Logger
+}
+
+func (i *Instances) Cleanup(ctx context.Context) error {
+	running, err := i.deployments.ListRunningInstances()
+	if err != nil {
+		return err
+	}
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	for _, instance := range running {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		if instance.Properties.Stopped != nil {
+			i.logger.Warn().
+				Str("uid", string(instance.UID)).
+				Msg("DeploymentInstance already stopped")
+			continue
+		}
+
+		deployment, found, err := i.deployments.Get(instance.Links.InstanceOfDeploymentUID)
+		if err != nil {
+			return err
+		}
+		if !found {
+			i.logger.Warn().
+				Str("uid", string(instance.Links.InstanceOfDeploymentUID)).
+				Msg("Deployment for DeploymentInstance not found in storage")
+			continue
+		}
+
+		environment, found, err := i.environments.Get(deployment.Links.DeployedInEnvironmentUID)
+		if err != nil {
+			return err
+		}
+		if !found {
+			i.logger.Warn().
+				Str("uid", string(deployment.Links.DeployedInEnvironmentUID)).
+				Msg("Environment for Deployment not found in storage")
+			continue
+		}
+
+		application, found, err := i.applications.Get(environment.Links.EnvironmentOfApplicationUID)
+		if err != nil {
+			return err
+		}
+		if !found {
+			i.logger.Warn().
+				Str("uid", string(environment.Links.EnvironmentOfApplicationUID)).
+				Msg("Application for Environment not found in storage")
+			continue
+		}
+
+		namespace := fmt.Sprintf("application-%s", application.Properties.ID)
+		selector, err := labels.ValidatedSelectorFromSet(labels.Set{
+			"application":  application.Properties.Name,
+			"environment":  environment.Properties.Name,
+			"microservice": deployment.Properties.Name,
+		})
+		if err != nil {
+			i.logger.Warn().
+				Err(err).
+				Msg("Failed to create pod selector")
+			continue
+		}
+
+		pods, err := i.pods.Pods(namespace).List(selector)
+		if err != nil {
+			return err
+		}
+
+		podStillRunning := false
+		for _, pod := range pods {
+			if string(pod.GetUID()) == instance.Properties.ID {
+				podStillRunning = true
+				break
+			}
+		}
+
+		if podStillRunning {
+			continue
+		}
+
+		i.logger.Info().
+			Str("uid", string(instance.UID)).
+			Msg("Marking DeploymentInstance as stopped since Pod doesn't exist anymore")
+
+		now := time.Now().UTC()
+		instance.Properties.Stopped = &now
+		err = i.deployments.SetInstance(instance)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cleanup/start.go
+++ b/cleanup/start.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Dolittle. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package cleanup
+
+import (
+	"context"
+	"dolittle.io/fleet-observer/storage"
+	"github.com/rs/zerolog"
+	"k8s.io/client-go/informers"
+	"time"
+)
+
+func StartAllCleanup(period time.Duration, factory informers.SharedInformerFactory, repositories *storage.Repositories, logger zerolog.Logger, ctx context.Context) {
+	instancesLogger := logger.With().Str("cleanup", "instances").Logger()
+	instances := &Instances{
+		deployments:  repositories.Deployments,
+		environments: repositories.Environments,
+		applications: repositories.Applications,
+		pods:         factory.Core().V1().Pods().Lister(),
+		logger:       instancesLogger,
+	}
+	go RunCleaner(instances, period, factory, instancesLogger, ctx)
+}
+
+type Cleaner interface {
+	Cleanup(ctx context.Context) error
+}
+
+func RunCleaner(cleaner Cleaner, period time.Duration, factory informers.SharedInformerFactory, logger zerolog.Logger, ctx context.Context) {
+	timer := time.NewTimer(1 * time.Second)
+
+	for {
+		factory.WaitForCacheSync(ctx.Done())
+
+		select {
+		case <-ctx.Done():
+			logger.Debug().Msg("Stopping cleanup")
+			return
+		case <-timer.C:
+		}
+
+		logger.Debug().Msg("Running cleanup")
+
+		err := cleaner.Cleanup(ctx)
+		if err == context.Canceled || err == context.DeadlineExceeded {
+			logger.Debug().Msg("Stopping cleanup")
+			return
+		}
+
+		if err != nil {
+			logger.Error().Err(err).Msg("Cleanup failed")
+		}
+
+		timer.Reset(period)
+	}
+}

--- a/cmd/observe.go
+++ b/cmd/observe.go
@@ -6,6 +6,7 @@
 package cmd
 
 import (
+	"dolittle.io/fleet-observer/cleanup"
 	"dolittle.io/fleet-observer/config"
 	"dolittle.io/fleet-observer/kubernetes"
 	"dolittle.io/fleet-observer/observing"
@@ -38,6 +39,8 @@ var observe = &cobra.Command{
 		}
 
 		observing.StartAllObservers(factory, repositories, logger, ctx)
+		cleanup.StartAllCleanup(config.Duration("cleanup.interval"), factory, repositories, logger, ctx)
+
 		go factory.Start(ctx.Done())
 
 		return WaitForStop(logger, ctx)
@@ -46,4 +49,5 @@ var observe = &cobra.Command{
 
 func init() {
 	observe.Flags().String("kubernetes.sync-interval", "1m", "The Kubernetes informer sync interval")
+	observe.Flags().String("cleanup.interval", "1m", "The interval to run cleanup jobs")
 }

--- a/entities/deployment.go
+++ b/entities/deployment.go
@@ -20,6 +20,7 @@ type Deployment struct {
 
 	Properties struct {
 		ID      string    `bson:"id" json:"id"`
+		Name    string    `bson:"name" json:"name"`
 		Created time.Time `bson:"created" json:"created"`
 	} `bson:"properties" json:"properties"`
 
@@ -34,11 +35,12 @@ func NewDeploymentUID(customerID, applicationID, environment, deploymentID strin
 	return DeploymentUID(fmt.Sprintf("%v/%v", NewEnvironmentUID(customerID, applicationID, environment), deploymentID))
 }
 
-func NewDeployment(customerID, applicationID, environment, id string, created time.Time, artifact ArtifactVersion, runtime RuntimeVersion) Deployment {
+func NewDeployment(customerID, applicationID, environment, id, name string, created time.Time, artifact ArtifactVersion, runtime RuntimeVersion) Deployment {
 	deployment := Deployment{}
 	deployment.UID = NewDeploymentUID(customerID, applicationID, environment, id)
 	deployment.Type = DeploymentType
 	deployment.Properties.ID = id
+	deployment.Properties.Name = name
 	deployment.Properties.Created = created
 	deployment.Links.DeployedInEnvironmentUID = NewEnvironmentUID(customerID, applicationID, environment)
 	deployment.Links.UsesArtifactVersionUID = artifact.UID

--- a/observing/replicasets.go
+++ b/observing/replicasets.go
@@ -56,6 +56,8 @@ func (rh *ReplicasetHandler) Handle(obj any, _deleted bool) error {
 		return nil
 	}
 
+	deploymentName := replicaset.GetLabels()["microservice"]
+
 	artifactVersionName := getArtifactVersionName(headContainer)
 	runtimeVersion, err := parseRuntimeVersion(runtimeContainer)
 	if err != nil {
@@ -91,6 +93,7 @@ func (rh *ReplicasetHandler) Handle(obj any, _deleted bool) error {
 		applicationID,
 		environmentName,
 		fmt.Sprintf("%v", replicaset.GetGeneration()),
+		deploymentName,
 		replicaset.GetCreationTimestamp().UTC(),
 		artifactVersion,
 		runtimeVersion,

--- a/storage/applications.go
+++ b/storage/applications.go
@@ -9,5 +9,6 @@ import "dolittle.io/fleet-observer/entities"
 
 type Applications interface {
 	Set(application entities.Application) error
+	Get(id entities.ApplicationUID) (*entities.Application, bool, error)
 	List() ([]entities.Application, error)
 }

--- a/storage/deployments.go
+++ b/storage/deployments.go
@@ -9,7 +9,9 @@ import "dolittle.io/fleet-observer/entities"
 
 type Deployments interface {
 	Set(deployment entities.Deployment) error
+	Get(id entities.DeploymentUID) (*entities.Deployment, bool, error)
 	List() ([]entities.Deployment, error)
 	SetInstance(instance entities.DeploymentInstance) error
 	ListInstances() ([]entities.DeploymentInstance, error)
+	ListRunningInstances() ([]entities.DeploymentInstance, error)
 }

--- a/storage/environments.go
+++ b/storage/environments.go
@@ -9,5 +9,6 @@ import "dolittle.io/fleet-observer/entities"
 
 type Environments interface {
 	Set(environment entities.Environment) error
+	Get(id entities.EnvironmentUID) (*entities.Environment, bool, error)
 	List() ([]entities.Environment, error)
 }

--- a/storage/mongo/applications.go
+++ b/storage/mongo/applications.go
@@ -31,6 +31,24 @@ func (a *Applications) Set(application entities.Application) error {
 	return err
 }
 
+func (a *Applications) Get(id entities.ApplicationUID) (*entities.Application, bool, error) {
+	result := a.collection.FindOne(a.ctx, bson.D{{"_id", id}})
+	err := result.Err()
+	if err == mongo.ErrNoDocuments {
+		return nil, false, nil
+	} else if err != nil {
+		return nil, true, err
+	}
+
+	application := &entities.Application{}
+	err = result.Decode(application)
+	if err != nil {
+		return nil, true, err
+	}
+
+	return application, true, nil
+}
+
 func (a *Applications) List() ([]entities.Application, error) {
 	cursor, err := a.collection.Find(a.ctx, bson.D{})
 	if err != nil {

--- a/storage/mongo/environments.go
+++ b/storage/mongo/environments.go
@@ -31,6 +31,24 @@ func (e *Environments) Set(environment entities.Environment) error {
 	return err
 }
 
+func (e *Environments) Get(id entities.EnvironmentUID) (*entities.Environment, bool, error) {
+	result := e.collection.FindOne(e.ctx, bson.D{{"_id", id}})
+	err := result.Err()
+	if err == mongo.ErrNoDocuments {
+		return nil, false, nil
+	} else if err != nil {
+		return nil, true, err
+	}
+
+	environment := &entities.Environment{}
+	err = result.Decode(environment)
+	if err != nil {
+		return nil, true, err
+	}
+
+	return environment, true, nil
+}
+
 func (e *Environments) List() ([]entities.Environment, error) {
 	cursor, err := e.collection.Find(e.ctx, bson.D{})
 	if err != nil {

--- a/storage/neo4j/deployments.go
+++ b/storage/neo4j/deployments.go
@@ -31,6 +31,7 @@ func (d *Deployments) Set(deployment entities.Deployment) error {
 		map[string]any{
 			"uid":                       deployment.UID,
 			"id":                        deployment.Properties.ID,
+			"name":                      deployment.Properties.Name,
 			"created":                   deployment.Properties.Created.Format(time.RFC3339),
 			"link_environment_uid":      deployment.Links.DeployedInEnvironmentUID,
 			"link_artifact_version_uid": deployment.Links.UsesArtifactVersionUID,
@@ -38,7 +39,7 @@ func (d *Deployments) Set(deployment entities.Deployment) error {
 		},
 		`
 			MERGE (deployment:Deployment { _uid: $uid })
-			SET deployment = { _uid: $uid, id: $id, created: datetime($created) }
+			SET deployment = { _uid: $uid, id: $id, name: $name, created: datetime($created) }
 			RETURN id(deployment)
 		`,
 		`


### PR DESCRIPTION
We didn't have names for `Deployment` - which made it hard to look at the data for humans. This was fixed by using the `microservice` label as the deployment name.

After running for a while - we also saw that there was a lot of _duplicates_ of `DeploymentInstance`. This seems mainly to have been caused by using the `ReplicaSet` `generation` property to uniquely identify them - but that was a simple mistake. The generation represents the number of times the `ReplicaSet` has changed, so each would start at `1` - and when a new deployment was made, it would be scaled down - and thus change the generation to `2`. The proper value to use here is the `deployment.kubernetes.io/revision` annotation - which reflects the generation of the deployment.

I also added a cleanup job that runs every now and then to mark a `DeploymentInstance` where the `Pod` no longer exists - as stopped. This would fix any missed `Pod` delete events that would not mark the instance as stopped.