### PR TITLE
Fix bug where DeploymentInstance was prematurely stopped by cleanup

### DIFF
--- a/cleanup/start.go
+++ b/cleanup/start.go
@@ -30,17 +30,17 @@ type Cleaner interface {
 }
 
 func RunCleaner(cleaner Cleaner, period time.Duration, factory informers.SharedInformerFactory, logger zerolog.Logger, ctx context.Context) {
-	timer := time.NewTimer(1 * time.Second)
+	timer := time.NewTimer(period)
 
 	for {
-		factory.WaitForCacheSync(ctx.Done())
-
 		select {
 		case <-ctx.Done():
 			logger.Debug().Msg("Stopping cleanup")
 			return
 		case <-timer.C:
 		}
+
+		factory.WaitForCacheSync(ctx.Done())
 
 		logger.Debug().Msg("Running cleanup")
 

--- a/storage/deployments.go
+++ b/storage/deployments.go
@@ -12,6 +12,7 @@ type Deployments interface {
 	Get(id entities.DeploymentUID) (*entities.Deployment, bool, error)
 	List() ([]entities.Deployment, error)
 	SetInstance(instance entities.DeploymentInstance) error
+	GetInstance(id entities.DeploymentInstanceUID) (*entities.DeploymentInstance, bool, error)
 	ListInstances() ([]entities.DeploymentInstance, error)
 	ListRunningInstances() ([]entities.DeploymentInstance, error)
 }

--- a/storage/mongo/deployments.go
+++ b/storage/mongo/deployments.go
@@ -71,6 +71,24 @@ func (d *Deployments) SetInstance(instance entities.DeploymentInstance) error {
 	return err
 }
 
+func (d *Deployments) GetInstance(id entities.DeploymentInstanceUID) (*entities.DeploymentInstance, bool, error) {
+	result := d.instancesCollection.FindOne(d.ctx, bson.D{{"_id", id}})
+	err := result.Err()
+	if err == mongo.ErrNoDocuments {
+		return nil, false, nil
+	} else if err != nil {
+		return nil, true, err
+	}
+
+	instance := &entities.DeploymentInstance{}
+	err = result.Decode(instance)
+	if err != nil {
+		return nil, true, err
+	}
+
+	return instance, true, nil
+}
+
 func (d *Deployments) ListInstances() ([]entities.DeploymentInstance, error) {
 	cursor, err := d.instancesCollection.Find(d.ctx, bson.D{})
 	if err != nil {


### PR DESCRIPTION
It seems like there was some sort of bug in the cleanup code that didn't find the expected running pods. By simplifying the logic and giving the cache more time to fill up - this should hopefully work better now.

Also, since we now might be stopping pods before they are deleted - update the delete pod handler logic to only set stopped to now if it is not already set.